### PR TITLE
Add Backlight trait.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,9 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt, clippy
       - name: Annotate commit with clippy warnings
@@ -28,7 +27,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+        uses: ionosphere-io/rust-actions-tarpaulin@v0.2
         with:
           version: latest
           args: '-- --test-threads 1'

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 Library that implements low-level protocol to the [Hitachi HD44780][1]-compatible LCD device.
 
 Provides high-level API to the [Hitachi HD44780][1]-compatible LCD device. Uses 4-bit mode
-by default (only uses 4 data pins) plus two control pins (R/S and EN). R/W pin is not used
-and should be wired for "write" (low-level, 0).
+by default (only uses 4 data pins) plus two control pins (R/S and EN). Using the R/W pin is optional;
+when `Hardware::can_read()` returns `false` (the default implementation), it is not used and should be
+wired for "write" (low-level, 0).
 
 The implementation is completely stateless. Client is free to reuse the same `Display` object
 or to create one every time access to LCD is required.
@@ -29,7 +30,7 @@ struct HW {
     // any data needed to access low-level peripherals
 }
 
-// implement `Hardware` trait to give access to LCD pins
+// Implement the `Hardware` trait to give access to LCD pins
 impl Hardware for HW {
     fn rs(&mut self, bit: bool) {
         // should set R/S pin on LCD screen
@@ -60,10 +61,17 @@ impl Hardware for HW {
     }
 }
 
-// implement `Delay` trait to allow library to sleep for the given amount of time
+// Implement the `Delay` trait to allow library to sleep for the given amount of time
 impl Delay for HW {
     fn delay_us(&mut self, delay_usec: u32) {
         // should sleep for the given amount of microseconds
+    }
+}
+
+// If your hardware has a backlight, implement `Backlight` trait to control it
+impl Backlight for HW {
+    fn set_backlight(&mut self, enable: bool) {
+        // configure pins to turn the backlight on/off.
     }
 }
 
@@ -78,6 +86,7 @@ lcd.display(
     DisplayMode::DisplayOn,
     DisplayCursor::CursorOff,
     DisplayBlink::BlinkOff);
+lcd.backlight(true); // available only if HW implements Backlight.
 lcd.entry_mode(EntryModeDirection::EntryRight, EntryModeShift::NoShift);
 
 // print something

--- a/tests/busy.rs
+++ b/tests/busy.rs
@@ -215,6 +215,38 @@ fn write_4bit() {
 }
 
 #[test]
+fn write_4bit_delay() {
+    let input = vec![0, 0];
+    let vec = crate::util::test_ignored_delay(FunctionMode::Bit4, Some(input), |lcd| {
+        lcd.write(b'a');
+    });
+
+    // Delay statements will be removed because the implementation doesn't capture them.
+    assert_eq!(
+        vec,
+        vec![
+            "R/S true",
+            "DATA 0b0110",
+            "EN true",
+            "EN false",
+            "DATA 0b0001",
+            "EN true",
+            "EN false",
+            "R/S false",
+            "RW true",
+            "EN true",
+            "IS BUSY?",
+            "EN false",
+            "EN true",
+            "IS BUSY?",
+            "EN false",
+            "RW false"
+        ]
+    );
+}
+
+
+#[test]
 fn write_8bit() {
     let input = vec![0];
     let vec = util::test(FunctionMode::Bit8, Some(input), |lcd| {

--- a/tests/no_busy.rs
+++ b/tests/no_busy.rs
@@ -4,7 +4,7 @@ extern crate lcd;
 
 mod util;
 use lcd::{
-    Direction, EntryModeDirection, EntryModeShift, FunctionDots, FunctionLine, FunctionMode,
+    Backlight, Direction, EntryModeDirection, EntryModeShift, FunctionDots, FunctionLine, FunctionMode,
 };
 
 #[test]
@@ -604,6 +604,24 @@ fn upload() {
             "EN false",
             "DELAY 50",
             "DELAY 5",
+        ]
+    );
+}
+
+#[test]
+fn backlight() {
+    let vec = util::test(FunctionMode::Bit4, None, |lcd| {
+        lcd.set_backlight(true);
+        lcd.set_backlight(false);
+        lcd.set_backlight(true);
+        
+    });
+    assert_eq!(
+        vec,
+        vec![
+            "BACKLIGHT true",
+            "BACKLIGHT false",
+            "BACKLIGHT true",
         ]
     );
 }


### PR DESCRIPTION
Add HardwareDelay convenience struct.

This adds an API for enabling/disabling backlights on a display. It also adds a HardwareDelay struct for cases where the Hardware and Delay implementations come from separate crates.

I also clarified the documentation a bit.